### PR TITLE
Fix #33

### DIFF
--- a/src/hi_getter/gui/menus/file.py
+++ b/src/hi_getter/gui/menus/file.py
@@ -19,7 +19,6 @@ from PySide6.QtWidgets import *
 
 from ...constants import *
 from ...models import DeferredCallable
-from ...utils.common import get_weakref_object
 from ...utils.gui import add_menu_items
 from ...utils.gui import init_objects
 from ..app import app
@@ -44,7 +43,8 @@ def export_data() -> None:
 
         7z, tar, zip, gztar, bztar, xztar
     """
-    export_dest = Path(QFileDialog.getSaveFileName(get_weakref_object(app().windows['app']), caption=tr('gui.menus.file.export'),
+    # noinspection PyTypeChecker
+    export_dest = Path(QFileDialog.getSaveFileName(None, caption=tr('gui.menus.file.export'),
                                                    dir=str(Path.home()), filter=_ARCHIVE_FILTER)[0])
     # Return early if no file selected
     if export_dest.is_dir():
@@ -72,7 +72,8 @@ def import_data() -> None:
 
         .7z .zip .piz .tar .tar.gz .tgz .tar.bz2 .tbz2 .tar.xz .txz
     """
-    archive_file = Path(QFileDialog.getOpenFileName(get_weakref_object(app().windows['app']), caption=tr('gui.menus.file.import'),
+    # noinspection PyTypeChecker
+    archive_file = Path(QFileDialog.getOpenFileName(None, caption=tr('gui.menus.file.import'),
                                                     dir=str(Path.home() / 'Downloads'), filter=_ARCHIVE_FILTER)[0])
     # Return early if no file selected
     if archive_file.is_dir():

--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -105,8 +105,8 @@ class AppWindow(Singleton, QMainWindow):
                 raise TypeError(f'{menu_class} is not a subclass of {QMenu}')
 
             menu: QMenu = menu_class(self)
-            menu.setAttribute(Qt.WA_DeleteOnClose)
             menu.exec(self.cursor().pos())
+            menu.deleteLater()
 
         init_objects({
             (menu_bar := QToolBar(self)): {},


### PR DESCRIPTION
Closes #33 

By synchronously deleting the menu, we can know for sure when the native dialog window is closed.

`menu.exec()` pauses the `QEventLoop` until all operations are done. After which, we mark it for deletion.
Before, since we were depending on the `Qt.WA_DeleteOnClose` attribute, the `FileContextMenu` would be deleted before
`menu.exec()` would return.

https://github.com/Cubicpath/HaloInfiniteGetter/blob/efa4395d270c22871fb18095a4a4dc1a4ead662c/src/hi_getter/gui/windows/application.py#L107-L109

If we used other methods to show the `QMenu`s (ex: `menu.show()` and `menu.popup()`), the `QEventLoop` wouldn't be paused,
and `menu.deleteLater()` would be called early. See: [PySide6.QtWidgets.QMenu.exec](https://doc.qt.io/qtforpython/PySide6/QtWidgets/QMenu.html#PySide6.QtWidgets.PySide6.QtWidgets.QMenu.exec)