### PR TITLE
Fix #31

### DIFF
--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -37,6 +37,7 @@ from ..app import app
 from ..app import tr
 from ..menus import *
 from ..widgets import *
+from ..workers import RecursiveSearch
 from .exception_reporter import ExceptionReporter
 
 
@@ -510,7 +511,7 @@ class AppWindow(Singleton, QMainWindow):
 
         if search_path:
             if scan:
-                app().client.recursive_search(search_path)
+                app().start_worker(RecursiveSearch(app().client, search_path))
             else:
                 app().client.get_hi_data(search_path)
 

--- a/src/hi_getter/gui/workers.py
+++ b/src/hi_getter/gui/workers.py
@@ -122,8 +122,8 @@ class RecursiveSearch(_Worker):
     def _run(self) -> None:
         self._recursive_search(self.search_path)
 
-    def _recursive_search(self, search_path: str):
-        if self.client.searched_paths.get(search_path, 0) >= 2:
+    def _recursive_search(self, search_path: str) -> None:
+        if self.client.searched_paths.get(search_path, 0) > 1:
             return
 
         data: dict[str, Any] | bytes | int = self.client.get_hi_data(search_path)

--- a/src/hi_getter/gui/workers.py
+++ b/src/hi_getter/gui/workers.py
@@ -56,8 +56,10 @@ class _Worker(QRunnable):
         Sends any uncaught :py:class:`Exception`'s through the ``exceptionRaised`` signal.
         """
         try:
+            # If the return value of the implemented _run function is not None, emit it through the `valueReturned` signal.
             if (ret_val := self._run()) is not None:
                 self.signals.valueReturned.emit(ret_val)
+
         except Exception as e:
             # This occurs when the application is exiting and an internal C++ object is being read after it is deleted.
             # So, return quietly and allow the process to exit with no errors.
@@ -66,7 +68,9 @@ class _Worker(QRunnable):
 
             self.signals.exceptionRaised.emit(e)
 
-        self.signals.deleteLater()
+        # Delete if not deleted
+        if shiboken6.isValid(self.signals):
+            self.signals.deleteLater()
 
 
 class ExportData(_Worker):

--- a/src/hi_getter/gui/workers.py
+++ b/src/hi_getter/gui/workers.py
@@ -55,6 +55,9 @@ class _Worker(QRunnable):
 
         Sends any uncaught :py:class:`Exception`'s through the ``exceptionRaised`` signal.
         """
+        # No idea how, but this fixes application deadlock cause by RecursiveSearch (issue #31)
+        QCoreApplication.instance().aboutToQuit.connect(lambda: None, Qt.BlockingQueuedConnection)
+
         try:
             # If the return value of the implemented _run function is not None, emit it through the `valueReturned` signal.
             if (ret_val := self._run()) is not None:

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -13,8 +13,6 @@ __all__ = (
 
 import json
 import os
-import random
-import time
 from pathlib import Path
 from typing import Any
 from typing import Final
@@ -125,7 +123,7 @@ class Client(QObject):
 
         return reply
 
-    def get_hi_data(self, path: str, dump_path: Path = WEB_DUMP_PATH, micro_sleep: bool = True) -> dict[str, Any] | bytes | int:
+    def get_hi_data(self, path: str, dump_path: Path = WEB_DUMP_PATH) -> dict[str, Any] | bytes | int:
         """Returns data from a path. Return type depends on the resource.
 
         :return: dict for JSON objects, bytes for media, int for error codes.
@@ -157,8 +155,6 @@ class Client(QObject):
             dump_data(os_path, data)
 
             reply.deleteLater()
-            if micro_sleep:
-                time.sleep(random.randint(100, 200) / 750)
 
         else:
             print(path)

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -21,7 +21,6 @@ from typing import Final
 
 from PySide6.QtCore import *
 from PySide6.QtNetwork import *
-from PySide6.QtWidgets import *
 
 from ..constants import *
 from ..models import CaseInsensitiveDict
@@ -29,6 +28,7 @@ from ..utils.common import dump_data
 from ..utils.network import decode_url
 from ..utils.network import guess_json_utf
 from ..utils.network import is_error_status
+from ..utils.network import wait_for_reply
 from ..utils.system import hide_windows_file
 from .manager import NetworkSession
 
@@ -113,8 +113,7 @@ class Client(QObject):
         :param kwargs: Key word arguments to pass to the requests GET Request.
         """
         reply: QNetworkReply = self.api_session.get(self.api_root + path.strip(), **kwargs)
-        while not reply.isFinished():
-            QApplication.processEvents()
+        wait_for_reply(reply)
 
         # None is returned if the request was aborted
         status_code: int | None = reply.attribute(QNetworkRequest.HttpStatusCodeAttribute)
@@ -195,10 +194,7 @@ class Client(QObject):
         wpauth MUST have a value for this to work. A lone 343 spartan token is not enough to generate a new one.
         """
         reply: QNetworkReply = self.web_session.get('https://www.halowaypoint.com/')
-
-        # TODO: After moving client to separate thread, remove this and QtWidgets import.
-        while not reply.isFinished():
-            QApplication.processEvents()
+        wait_for_reply(reply)
 
         wpauth: str = decode_url(self.web_session.cookies.get('wpauth') or '')
         token:  str = decode_url(self.web_session.cookies.get('343-spartan-token') or '')

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -26,7 +26,6 @@ from PySide6.QtWidgets import *
 from ..constants import *
 from ..models import CaseInsensitiveDict
 from ..utils.common import dump_data
-from ..utils.common import unique_values
 from ..utils.network import decode_url
 from ..utils.network import guess_json_utf
 from ..utils.network import is_error_status
@@ -189,28 +188,6 @@ class Client(QObject):
         resource = path.split(self.parent_path, maxsplit=1)[1]
         pre, post = resource.split("/", maxsplit=1)
         return f'{pre}/file/{post}'
-
-    def recursive_search(self, search_path: str) -> None:
-        """Recursively get Halo Waypoint files linked to the search_path through Mapping keys."""
-        if self.searched_paths.get(search_path, 0) >= 2:
-            return
-
-        data: dict[str, Any] | bytes | int = self.get_hi_data(search_path)
-        if isinstance(data, (bytes, int)):
-            return
-
-        for value in unique_values(data):
-            if isinstance(value, str):
-                if '/' not in value:
-                    continue
-
-                end = value.split('.')[-1].lower()
-                if end in ('json',):
-                    path = 'progression/file/' + value
-                    self.searched_paths.update({path: self.searched_paths.get(path, 0) + 1})
-                    self.recursive_search(path)
-                elif end in SUPPORTED_IMAGE_EXTENSIONS:
-                    self.get_hi_data('images/file/' + value)
 
     def refresh_auth(self) -> None:
         """Refreshes authentication to Halo Waypoint servers.

--- a/src/hi_getter/utils/network.py
+++ b/src/hi_getter/utils/network.py
@@ -13,6 +13,7 @@ __all__ = (
     'http_code_map',
     'is_error_status',
     'query_to_dict',
+    'wait_for_reply',
 )
 
 import codecs
@@ -68,6 +69,16 @@ def query_to_dict(query: QUrlQuery | str) -> dict[str, str]:
 def is_error_status(status: int) -> bool:
     """Returns True if the HTTP status code is an error status."""
     return 400 <= status < 600
+
+
+def wait_for_reply(reply: QNetworkReply) -> None:
+    """Process events until the reply is finished.
+
+    :param reply: The QNetworkReply to wait for.
+    :raises RuntimeError: If the internal C++ QNetworkRequest is deleted.
+    """
+    while not reply.isFinished():
+        QCoreApplication.processEvents()
 
 
 # NOTICE:


### PR DESCRIPTION
Closes #31

Side-effects include:
- No micro-sleeps after a request is sent
- `recursive_search` is now on a separate worker thread
- `RuntimeError`s caused by application exit are caught by the `_Worker`