### PR TITLE
Changelog Viewer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Changelog Viewer
+    - Ability to see the latest version in **bold**
 
 ## [0.12] - 2022-11-3 - [PyPI](https://pypi.org/project/hi-getter/0.12/)
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Changelog Viewer
+
 ## [0.12] - 2022-11-3 - [PyPI](https://pypi.org/project/hi-getter/0.12/)
 ### Added
 - `CHANGELOG.md`
@@ -24,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - ZIP Files (`*.zip` & `*.piz`)
     - TAR Files (`*.tar`, `*.tar.gz`, `*.tgz`, `*.tar.bz2`, `*.tbz2`, `*.tar.xz`, `*.txz`)
         - `gzip`, `bzip2`, and `xz` are the supported compression algorithms
-
 
 ### Changed
 - Cache Explorer `Open in Default App` now shows the default icon for the file

--- a/src/hi_getter/constants.py
+++ b/src/hi_getter/constants.py
@@ -83,7 +83,7 @@ MARKDOWN_IMG_LINK_PATTERN: Final[re.Pattern] = re.compile(
 """Regex pattern for finding image links."""
 
 MARKDOWN_REF_LINK_PATTERN: Final[re.Pattern] = re.compile(
-    r'\[(?P<label>[ \w()-]+)] *: *'
+    r'\[(?P<label>[^\[\]]+)] *: *'
     r'(?P<url>(?:(?:[a-zA-Z]+)?://)?'
     r'\w+(?:\.\w+)*(?::\d{1,5})?'
     r'(?:/[^\s()]*)?(?:\?(?:\w+=\w+&?)+)?)'

--- a/src/hi_getter/gui/__init__.py
+++ b/src/hi_getter/gui/__init__.py
@@ -24,14 +24,18 @@ __all__ = (
 
 from .app import GetterApp
 from .app import Theme
+from .menus import CacheIndexContextMenu
+from .menus import ColumnContextMenu
 from .menus import FileContextMenu
 from .menus import HelpContextMenu
 from .menus import ToolsContextMenu
+from .widgets import CacheExplorer
 from .widgets import ExceptionLogger
 from .widgets import ExternalTextBrowser
 from .widgets import HistoryComboBox
 from .widgets import PasteLineEdit
 from .windows import AppWindow
+from .windows import ChangelogViewer
 from .windows import ExceptionReporter
 from .windows import LicenseViewer
 from .windows import ReadmeViewer

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -164,6 +164,7 @@ class GetterApp(Singleton, QApplication):
     def _create_windows(self, **kwargs) -> None:
         """Create window instances."""
         from .windows import AppWindow
+        from .windows import ChangelogViewer
         from .windows import LicenseViewer
         from .windows import ReadmeViewer
         from .windows import SettingsWindow
@@ -175,6 +176,7 @@ class GetterApp(Singleton, QApplication):
             max(kwargs.pop('y_size', self.settings['gui/window/y_size']), 100)
         ))
 
+        self._windows['changelog_viewer'] = ChangelogViewer()
         self._windows['license_viewer'] = LicenseViewer()
         self._windows['readme_viewer'] = ReadmeViewer()
         self._windows['settings'] = SettingsWindow.instance()

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -200,16 +200,19 @@ class GetterApp(Singleton, QApplication):
         shutil.register_archive_format('7z', pack_7zarchive, description='7Zip Archive File')
         shutil.register_unpack_format('7z', ['7z'], unpack_7zarchive, description='7Zip Archive File')
 
-    def init_translations(self, translation_calls: dict[Callable, str]) -> None:
+    def init_translations(self, translation_calls: dict[Callable, str | tuple[Any, ...]]) -> None:
         """Initialize the translation of all objects.
 
         Register functions to call with their respective translation keys.
         This is used to translate everything in the GUI.
         """
 
-        for func, key in translation_calls.items():
+        for func, args in translation_calls.items():
+            if not isinstance(args, tuple):
+                args = (args,)
+
             # Call the function with the deferred translation of the given key.
-            translate = DeferredCallable(func, DeferredCallable(self.translator, key))
+            translate = DeferredCallable(func, DeferredCallable(self.translator, *args))
 
             # Register the object for dynamic translation
             self._registered_translations.callables.add(translate)

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -37,6 +37,7 @@ from ..models import Singleton
 from ..network.client import Client
 from ..network.client import WEB_DUMP_PATH
 from ..network.manager import NetworkSession
+from ..network.version_check import VersionChecker
 from ..tomlfile import *
 from ..utils.gui import icon_from_bytes
 from ..utils.gui import set_or_swap_icon
@@ -110,6 +111,7 @@ class GetterApp(Singleton, QApplication):
         self.themes: dict[str, Theme] = {}
         self.theme_index_map: dict[str, int] = {}
         self.translator: Translator = Translator(self.settings['language'])
+        self.version_checker: VersionChecker = VersionChecker(self)
 
         # Load resources from disk
         self.load_themes()  # Depends on icon_store, settings, themes, theme_index_map
@@ -130,6 +132,9 @@ class GetterApp(Singleton, QApplication):
 
         # Create window instances
         self._create_windows(**kwargs)
+
+        # Check version after all widgets are created to listen for newerVersion signal
+        self.version_checker.check_version()
 
     @property
     def first_launch(self) -> bool:

--- a/src/hi_getter/gui/menus/help.py
+++ b/src/hi_getter/gui/menus/help.py
@@ -75,6 +75,12 @@ class HelpContextMenu(QMenu):
                 )
             },
 
+            (changelog := QAction(self)): {
+                'text': tr('gui.menus.help.changelog'),
+                'icon': app().get_theme_icon('message_information') or self.style().standardIcon(QStyle.SP_DialogApplyButton),
+                'triggered': lambda: app().windows['changelog_viewer'].show()
+            },
+
             (license_view := QAction(self)): {
                 'text': tr('gui.menus.help.license'),
                 'icon': app().icon_store['copyright'],
@@ -90,7 +96,7 @@ class HelpContextMenu(QMenu):
 
         add_menu_items(self, [
             'Github', github_view, create_issue,
-            'Information', about_view, about_qt_view, license_view, readme
+            'Information', changelog, about_view, about_qt_view, license_view, readme
         ])
 
     # pylint: disable=not-an-iterable

--- a/src/hi_getter/gui/menus/help.py
+++ b/src/hi_getter/gui/menus/help.py
@@ -96,7 +96,8 @@ class HelpContextMenu(QMenu):
 
         add_menu_items(self, [
             'Github', github_view, create_issue,
-            'Information', changelog, about_view, about_qt_view, license_view, readme
+            'Docs', changelog, readme,
+            'About', about_view, about_qt_view, license_view
         ])
 
     # pylint: disable=not-an-iterable

--- a/src/hi_getter/gui/widgets/__init__.py
+++ b/src/hi_getter/gui/widgets/__init__.py
@@ -5,6 +5,7 @@
 
 __all__ = (
     'CacheExplorer',
+    'ComboBox',
     'ExceptionLogger',
     'ExternalTextBrowser',
     'HistoryComboBox',

--- a/src/hi_getter/gui/widgets/external_text_browser.py
+++ b/src/hi_getter/gui/widgets/external_text_browser.py
@@ -101,7 +101,8 @@ class ExternalTextBrowser(QTextBrowser):
                     if has_hashtag or has_underline:
                         simple_str: str = line.strip().replace(' ', '-').replace(':', '').lstrip('#').strip('-').lower()
 
-                        lines_new.append(f'{line} <a name="{simple_str}" href="#{simple_str}">§</a>')
+                        anchor_css = 'font-size: 1px; color: transparent'
+                        lines_new.append(f'{line} <a name="{simple_str}" href="#{simple_str}" style="{anchor_css}">§</a>')
                         continue
 
                 lines_new.append(line)

--- a/src/hi_getter/gui/widgets/external_text_browser.py
+++ b/src/hi_getter/gui/widgets/external_text_browser.py
@@ -34,6 +34,7 @@ class ExternalTextBrowser(QTextBrowser):
 
         # default factory producing empty DeferredCallables
         self.key_callable_map: defaultdict[int, Callable] = defaultdict(DeferredCallable)
+        self.inject_markdown_anchors: bool = True
         self.cached_text: str = ''
         self.cached_type: str = ''
 
@@ -87,20 +88,22 @@ class ExternalTextBrowser(QTextBrowser):
                     continue
 
                 # Find headers and add relative anchors
-                has_hashtag:   bool = line.strip().startswith('#')
-                has_underline: bool = line and (i < len(lines) - 1) and any(
-                    # Line must end and begin with the respective underline
-                    lines[i + 1].strip().startswith(line_char) and
-                    lines[i + 1].strip().endswith(line_char) for line_char in ('-', '=')
-                )
+                if self.inject_markdown_anchors:
+                    has_hashtag:   bool = line.strip().startswith('#')
+                    has_underline: bool = line and (i < len(lines) - 1) and any(
+                        # Line must end and begin with the respective underline
+                        lines[i + 1].strip().startswith(line_char) and
+                        lines[i + 1].strip().endswith(line_char) for line_char in ('-', '=')
+                    )
 
-                # If line has a header marker, append it with an anchor tag and add it to the new list.
-                # Otherwise, append the unchanged line to the new list.
-                if has_hashtag or has_underline:
-                    simple_str: str = line.strip().replace(' ', '-').replace(':', '').lstrip('#').strip('-').lower()
+                    # If line has a header marker, append it with an anchor tag and add it to the new list.
+                    # Otherwise, append the unchanged line to the new list.
+                    if has_hashtag or has_underline:
+                        simple_str: str = line.strip().replace(' ', '-').replace(':', '').lstrip('#').strip('-').lower()
 
-                    lines_new.append(f'{line} <a name="{simple_str}" href="#{simple_str}">§</a>')
-                    continue
+                        lines_new.append(f'{line} <a name="{simple_str}" href="#{simple_str}">§</a>')
+                        continue
+
                 lines_new.append(line)
 
             text = '\n'.join(lines_new)

--- a/src/hi_getter/gui/windows/__init__.py
+++ b/src/hi_getter/gui/windows/__init__.py
@@ -5,6 +5,7 @@
 
 __all__ = (
     'AppWindow',
+    'ChangelogViewer',
     'ExceptionReporter',
     'LicenseViewer',
     'ReadmeViewer',
@@ -12,6 +13,7 @@ __all__ = (
 )
 
 from .application import AppWindow
+from .changelog_viewer import ChangelogViewer
 from .exception_reporter import ExceptionReporter
 from .license_viewer import LicenseViewer
 from .readme_viewer import ReadmeViewer

--- a/src/hi_getter/gui/windows/changelog_viewer.py
+++ b/src/hi_getter/gui/windows/changelog_viewer.py
@@ -13,6 +13,7 @@ from PySide6.QtGui import *
 from PySide6.QtNetwork import *
 from PySide6.QtWidgets import *
 
+from ..._version import __version__
 from ...models import DeferredCallable
 from ...utils.gui import init_layouts
 from ...utils.gui import init_objects
@@ -42,12 +43,20 @@ class ChangelogViewer(QWidget):
                 'font': QFont(self.text_browser.font().family(), 10),
                 'openExternalLinks': True
             },
+
+            (version_label := QLabel(self)): {},
+
+            (spacer := QSpacerItem(0, 0, hData=QSizePolicy.MinimumExpanding)): {},
+
             (github_button := QPushButton(self)): {
+                'size': {'fixed': (180, None)},
                 'clicked': DeferredCallable(
                     QDesktopServices.openUrl, QUrl('https://github.com/Cubicpath/HaloInfiniteGetter/blob/master/CHANGELOG.md')
                 )
             },
+
             (releases_button := QPushButton(self)): {
+                'size': {'fixed': (110, None)},
                 'clicked': DeferredCallable(
                     QDesktopServices.openUrl, QUrl('https://github.com/Cubicpath/HaloInfiniteGetter/releases')
                 )
@@ -56,13 +65,14 @@ class ChangelogViewer(QWidget):
 
         app().init_translations({
             self.setWindowTitle: 'gui.changelog_viewer.title',
+            version_label.setText: ('gui.changelog_viewer.current_version', __version__),
             github_button.setText: 'gui.changelog_viewer.github',
             releases_button.setText: 'gui.changelog_viewer.releases'
         })
 
         init_layouts({
             (buttons := QHBoxLayout()): {
-                'items': [github_button, releases_button]
+                'items': [version_label, spacer, github_button, releases_button]
             },
 
             # Main layout
@@ -71,7 +81,6 @@ class ChangelogViewer(QWidget):
             }
         })
 
-        self.text_browser.inject_markdown_anchors = False
         self.update_changelog()
 
     def update_changelog(self) -> None:

--- a/src/hi_getter/gui/windows/changelog_viewer.py
+++ b/src/hi_getter/gui/windows/changelog_viewer.py
@@ -61,9 +61,18 @@ class ChangelogViewer(QWidget):
         """Updates the displayed text to the data from the changelog url."""
 
         def handle_reply(reply: QNetworkReply):
-            # Add separators between versions and remove primary header
             text: str = reply.readAll().data().decode('utf8')
-            text = '\n-----\n## '.join(text.split('\n## ')[1:])
+            # Add separators between versions and remove primary header
+            text = '## ' + '\n-----\n## '.join(text.split('\n## ')[1:])
+
+            # The Markdown Renderer doesn't accept headers with ref_links, so remove them
+            new_lines = []
+            for line in text.splitlines():
+                if line.startswith('## '):
+                    line = line.replace('[', '', 1).replace(']', '', 1)
+
+                new_lines.append(line)
+            text = '\n'.join(new_lines)
 
             self.text_browser.set_hot_reloadable_text(text, 'markdown')
             reply.deleteLater()

--- a/src/hi_getter/gui/windows/changelog_viewer.py
+++ b/src/hi_getter/gui/windows/changelog_viewer.py
@@ -54,6 +54,7 @@ class ChangelogViewer(QWidget):
             }
         })
 
+        self.text_browser.inject_markdown_anchors = False
         self.update_changelog()
 
     def update_changelog(self) -> None:

--- a/src/hi_getter/gui/windows/changelog_viewer.py
+++ b/src/hi_getter/gui/windows/changelog_viewer.py
@@ -1,0 +1,70 @@
+###################################################################################################
+#                              MIT Licence (C) 2022 Cubicpath@Github                              #
+###################################################################################################
+"""ReadmeViewer implementation."""
+from __future__ import annotations
+
+__all__ = (
+    'ChangelogViewer',
+)
+
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtNetwork import *
+from PySide6.QtWidgets import *
+
+from ...utils.gui import init_layouts
+from ...utils.gui import init_objects
+from ..app import app
+from ..app import tr
+from ..widgets import ExternalTextBrowser
+
+
+class ChangelogViewer(QWidget):
+    """Widget that formats and shows the project's README.md, stored in the projects 'Description' metadata tag."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.setWindowTitle(tr('gui.changelog_viewer.title'))
+        self.setWindowIcon(app().get_theme_icon('message_information') or self.style().standardIcon(QStyle.SP_DialogApplyButton))
+        self.resize(QSize(750, 750))
+
+        self.changelog_url: str = 'https://raw.githubusercontent.com/Cubicpath/HaloInfiniteGetter/master/CHANGELOG.md'
+        self.text_browser: ExternalTextBrowser
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        self.text_browser = ExternalTextBrowser(self)
+
+        init_objects({
+            self.text_browser: {
+                'font': QFont(self.text_browser.font().family(), 10),
+                'openExternalLinks': True
+            }
+        })
+
+        app().init_translations({
+            self.setWindowTitle: 'gui.changelog_viewer.title'
+        })
+
+        init_layouts({
+            # Main layout
+            QVBoxLayout(self): {
+                'items': [self.text_browser]
+            }
+        })
+
+        self.update_changelog()
+
+    def update_changelog(self) -> None:
+        """Updates the displayed text to the data from the changelog url."""
+
+        def handle_reply(reply: QNetworkReply):
+            # Add separators between versions and remove primary header
+            text: str = reply.readAll().data().decode('utf8')
+            text = '\n-----\n## '.join(text.split('\n## ')[1:])
+
+            self.text_browser.set_hot_reloadable_text(text, 'markdown')
+            reply.deleteLater()
+
+        app().session.get(self.changelog_url, finished=handle_reply)

--- a/src/hi_getter/gui/windows/changelog_viewer.py
+++ b/src/hi_getter/gui/windows/changelog_viewer.py
@@ -8,6 +8,8 @@ __all__ = (
     'ChangelogViewer',
 )
 
+import random
+
 from PySide6.QtCore import *
 from PySide6.QtGui import *
 from PySide6.QtNetwork import *
@@ -93,7 +95,7 @@ class ChangelogViewer(QWidget):
         })
 
         app().version_checker.newerVersion.connect(self.update_latest_version)
-        app().version_checker.checked.connect(lambda: QTimer.singleShot(750, DistributedCallable((
+        app().version_checker.checked.connect(lambda: QTimer.singleShot(random.randint(250, 500), DistributedCallable((
             check_latest_button.setDisabled,
             self.version_label.setDisabled
         ), False)))

--- a/src/hi_getter/gui/windows/changelog_viewer.py
+++ b/src/hi_getter/gui/windows/changelog_viewer.py
@@ -13,6 +13,7 @@ from PySide6.QtGui import *
 from PySide6.QtNetwork import *
 from PySide6.QtWidgets import *
 
+from ...models import DeferredCallable
 from ...utils.gui import init_layouts
 from ...utils.gui import init_objects
 from ..app import app
@@ -27,7 +28,7 @@ class ChangelogViewer(QWidget):
         super().__init__(*args, **kwargs)
         self.setWindowTitle(tr('gui.changelog_viewer.title'))
         self.setWindowIcon(app().get_theme_icon('message_information') or self.style().standardIcon(QStyle.SP_DialogApplyButton))
-        self.resize(QSize(750, 750))
+        self.resize(QSize(600, 800))
 
         self.changelog_url: str = 'https://raw.githubusercontent.com/Cubicpath/HaloInfiniteGetter/master/CHANGELOG.md'
         self.text_browser: ExternalTextBrowser
@@ -40,17 +41,33 @@ class ChangelogViewer(QWidget):
             self.text_browser: {
                 'font': QFont(self.text_browser.font().family(), 10),
                 'openExternalLinks': True
+            },
+            (github_button := QPushButton(self)): {
+                'clicked': DeferredCallable(
+                    QDesktopServices.openUrl, QUrl('https://github.com/Cubicpath/HaloInfiniteGetter/blob/master/CHANGELOG.md')
+                )
+            },
+            (releases_button := QPushButton(self)): {
+                'clicked': DeferredCallable(
+                    QDesktopServices.openUrl, QUrl('https://github.com/Cubicpath/HaloInfiniteGetter/releases')
+                )
             }
         })
 
         app().init_translations({
-            self.setWindowTitle: 'gui.changelog_viewer.title'
+            self.setWindowTitle: 'gui.changelog_viewer.title',
+            github_button.setText: 'gui.changelog_viewer.github',
+            releases_button.setText: 'gui.changelog_viewer.releases'
         })
 
         init_layouts({
+            (buttons := QHBoxLayout()): {
+                'items': [github_button, releases_button]
+            },
+
             # Main layout
             QVBoxLayout(self): {
-                'items': [self.text_browser]
+                'items': [buttons, self.text_browser]
             }
         })
 

--- a/src/hi_getter/network/version_check.py
+++ b/src/hi_getter/network/version_check.py
@@ -1,0 +1,83 @@
+###################################################################################################
+#                              MIT Licence (C) 2022 Cubicpath@Github                              #
+###################################################################################################
+"""Version checking and validation."""
+from __future__ import annotations
+
+__all__ = (
+    'is_greater_version',
+    'VersionChecker',
+)
+
+import json
+from datetime import datetime
+from importlib.metadata import version
+# noinspection PyProtectedMember, PyUnresolvedReferences
+from setuptools._vendor.packaging.version import Version
+from typing import Any
+
+from PySide6.QtCore import *
+from PySide6.QtNetwork import *
+
+from .._version import __version__
+from ..constants import *
+from ..utils.network import guess_json_utf
+from ..utils.package import has_package
+from .manager import NetworkSession
+
+
+def get_version(package_name: str) -> Version | None:
+    """Return the :py:class:`Version` of the given package if it is installed. Else return None."""
+    if has_package(package_name):
+        return Version(version(package_name))
+
+
+def is_greater_version(version1: str, version2: str) -> bool:
+    """Return whether ``version1`` is greater than ``version2``."""
+    if not isinstance(version1, Version):
+        version1 = Version(version1)
+    if not isinstance(version2, Version):
+        version2 = Version(version2)
+
+    return version1 > version2
+
+
+class VersionChecker(QObject):
+    """Checks for the latest versions of packages."""
+    newerVersion = Signal(str, str, name='versionChecked')
+
+    def __init__(self, parent: QObject | None = None) -> None:
+        super().__init__(parent)
+
+        self.session: NetworkSession = NetworkSession(self)
+
+    def check_version(self, package_name: str = HI_PACKAGE_NAME) -> None:
+        """Check the latest version of the given package on PyPI.
+
+        If the latest version is greater than the current version,
+        emit the ``newerVersion`` signal with the given name and the latest version as arguments
+
+        :param package_name: The package to look up on PyPI
+        """
+        def handle_reply(reply: QNetworkReply):
+            # Get PyPI data from reply
+            data_bytes: bytes = reply.readAll().data()
+            data: dict[str, Any] = json.loads(data_bytes.decode(guess_json_utf(data_bytes)))
+            date_format: str = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+            # Sort versions on date released
+            versions: list[str] = sorted(
+                releases := data['releases'],
+                key=lambda v: datetime.strptime(releases[v][0]['upload_time_iso_8601'], date_format)
+            )
+
+            local_version: str | None = get_version(package_name) if package_name != HI_PACKAGE_NAME else __version__
+
+            # Get the latest version and compare to current version. Emit newerVersion if greater.
+            latest: str = versions[-1]
+            if is_greater_version(latest, local_version):
+                self.newerVersion.emit(package_name, latest)
+
+            reply.deleteLater()
+
+        self.session.get(f'https://pypi.org/pypi/{package_name.replace("_", "-").strip()}/json', finished=handle_reply)

--- a/src/hi_getter/resources/lang/en_us.json
+++ b/src/hi_getter/resources/lang/en_us.json
@@ -40,7 +40,7 @@
     "gui.changelog_viewer.github": "View Changelog on GitHub",
     "gui.changelog_viewer.releases": "View Releases",
     "gui.changelog_viewer.title": "Changelog Viewer",
-    "gui.changelog_viewer.current_version": "<b>Current Version: v%s</b>",
+    "gui.changelog_viewer.current_version": "Latest: v%s | Current: v%s",
     "gui.exception_reporter.clear": "Clear",
     "gui.exception_reporter.clear_all": "Clear All",
     "gui.exception_reporter.exception_list": "List of all currently logged exceptions:",

--- a/src/hi_getter/resources/lang/en_us.json
+++ b/src/hi_getter/resources/lang/en_us.json
@@ -37,6 +37,7 @@
     "questions.create_shortcut.description": "Please choose the location you would like the shortcut to be in.",
     "questions.create_shortcut.title": "Shortcut Creation Tool",
 
+    "gui.changelog_viewer.title": "Changelog Viewer",
     "gui.exception_reporter.clear": "Clear",
     "gui.exception_reporter.clear_all": "Clear All",
     "gui.exception_reporter.exception_list": "List of all currently logged exceptions:",
@@ -90,6 +91,7 @@
     "gui.menus.help": "Help",
     "gui.menus.help.about": "About",
     "gui.menus.help.about_qt": "About Qt",
+    "gui.menus.help.changelog": "Changelog",
     "gui.menus.help.github": "View on Github",
     "gui.menus.help.issue": "Create an Issue",
     "gui.menus.help.license": "License",

--- a/src/hi_getter/resources/lang/en_us.json
+++ b/src/hi_getter/resources/lang/en_us.json
@@ -40,6 +40,7 @@
     "gui.changelog_viewer.github": "View Changelog on GitHub",
     "gui.changelog_viewer.releases": "View Releases",
     "gui.changelog_viewer.title": "Changelog Viewer",
+    "gui.changelog_viewer.current_version": "<b>Current Version: v%s</b>",
     "gui.exception_reporter.clear": "Clear",
     "gui.exception_reporter.clear_all": "Clear All",
     "gui.exception_reporter.exception_list": "List of all currently logged exceptions:",

--- a/src/hi_getter/resources/lang/en_us.json
+++ b/src/hi_getter/resources/lang/en_us.json
@@ -37,6 +37,8 @@
     "questions.create_shortcut.description": "Please choose the location you would like the shortcut to be in.",
     "questions.create_shortcut.title": "Shortcut Creation Tool",
 
+    "gui.changelog_viewer.github": "View Changelog on GitHub",
+    "gui.changelog_viewer.releases": "View Releases",
     "gui.changelog_viewer.title": "Changelog Viewer",
     "gui.exception_reporter.clear": "Clear",
     "gui.exception_reporter.clear_all": "Clear All",


### PR DESCRIPTION
With the addition of the CHANGELOG in [v0.12](https://github.com/Cubicpath/HaloInfiniteGetter/releases/tag/v0.12), it would only be appropriate if you could view it natively in HaloInfiniteGetter.

A window containing the changelog could appear on a new release, prompting the user if they want to download the latest version.
You will also have the option to view the changelog anytime through the `Changelog` action in the `Help` context menu.