### PR TITLE
Asynchronous Client Requests

### DIFF
--- a/src/hi_getter/gui/menus/file.py
+++ b/src/hi_getter/gui/menus/file.py
@@ -141,5 +141,6 @@ class FileContextMenu(QMenu):
         ).role == QMessageBox.ButtonRole.AcceptRole
 
         if do_flush:
+            app().client.searched_paths.clear()
             QDir(HI_CACHE_PATH).removeRecursively()
             HI_CACHE_PATH.mkdir(exist_ok=True)

--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -508,15 +508,7 @@ class AppWindow(Singleton, QMainWindow):
         if not (user_input := self.input_field.currentText()):
             return
 
-        search_path = user_input.strip()
-
-        if '/file/' not in user_input:
-            if search_path.split('.')[-1] in SUPPORTED_IMAGE_EXTENSIONS:
-                search_path = f'images/file/{search_path}'
-            else:
-                search_path = f'progression/file/{search_path}'
-
-        if search_path:
+        if search_path := user_input.strip():
             if scan:
                 app().client.recursive_search(search_path)
             else:

--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -42,7 +42,6 @@ from ..widgets import HistoryComboBox
 from ..widgets import ExceptionLogger
 from ..widgets import ExternalTextBrowser
 from ..widgets import PasteLineEdit
-from ..workers import RecursiveSearch
 from .exception_reporter import ExceptionReporter
 
 
@@ -519,7 +518,7 @@ class AppWindow(Singleton, QMainWindow):
 
         if search_path:
             if scan:
-                app().start_worker(RecursiveSearch(app().client, search_path))
+                app().client.recursive_search(search_path)
             else:
                 app().client.get_hi_data(search_path)
 

--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -615,6 +615,7 @@ class AppWindow(Singleton, QMainWindow):
                 app().show_dialog('warnings.photosensitivity.scan')
                 warned_file.write('warnings.photosensitivity.scan\n')
 
+        app().client.searched_paths.clear()
         self.use_input(scan=True)
 
     # # # # # Events

--- a/src/hi_getter/gui/workers.py
+++ b/src/hi_getter/gui/workers.py
@@ -7,20 +7,14 @@ from __future__ import annotations
 __all__ = (
     'ExportData',
     'ImportData',
-    'RecursiveSearch',
 )
 
 import shutil
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any
 
 from PySide6.QtCore import *
 from shiboken6 import Shiboken
-
-from ..constants import *
-from ..network import Client
-from ..utils import unique_values
 
 
 class _SignalHolder(QObject):
@@ -64,7 +58,7 @@ class _Worker(QRunnable):
         if (app := QCoreApplication.instance()) is None:
             raise RuntimeError('Worker started before application instance is defined.')
 
-        # No idea how, but this fixes application deadlock cause by RecursiveSearch (issue #31)
+        # Workaround for application deadlock (issue #31)
         app.aboutToQuit.connect(  # pyright: ignore[reportGeneralTypeIssues]
             self._dummy_method, Qt.ConnectionType.BlockingQueuedConnection
         )
@@ -134,54 +128,3 @@ class ImportData(_Worker):
 
     def _run(self) -> None:
         shutil.unpack_archive(str(self.archive), extract_dir=self.dest)
-
-
-class RecursiveSearch(_Worker):
-    """Recursively get Halo Waypoint files linked to the search_path through Mapping keys."""
-
-    def __init__(self, client: Client, search_path: str, **kwargs: Callable | Slot) -> None:
-        """Create a new :py:class:`RecursiveSearch` worker to use the given ``client`` and base ``search_path``."""
-        super().__init__(**kwargs)
-        self.client = client
-        self.search_path = search_path
-
-    def _run(self) -> None:
-        self.client.receivedJson.connect(self._recursive_search)
-        self.client.get_hi_data(self.search_path)
-
-    def _recursive_search(self, path: str, data: dict[str, Any] | bytes | int):
-        # This set is shared between all recursive calls, so no duplicate searches should occur
-        searched: set[str] = self.client.searched_paths
-        searched.add(path.lower())
-
-        if isinstance(data, (bytes, int)):
-            return
-
-        # Iterate over all values in the JSON data
-        # This process ignores already-searched values
-        for value in unique_values(data):
-            if isinstance(value, str) and (match := HI_PATH_PATTERN.match(value)):
-                path = match[0]
-                ext: str = match['file_name'].split('.')[-1].lower()
-                has_pre_path: bool = match['pre_path'] is not None
-
-                # If a value ends in .json, get the data for that path and start the process over again
-                if ext in {'json'}:
-                    if not has_pre_path:
-                        path = 'progression/file/' + path
-
-                    if path.lower() in searched:
-                        continue
-
-                    self.client.get_hi_data(path)
-
-                # If it's an image, download it then ignore the result
-                elif ext in SUPPORTED_IMAGE_EXTENSIONS:
-                    if not has_pre_path:
-                        path = 'images/file/' + path
-
-                    if path.lower() in searched:
-                        continue
-
-                    searched.add(path.lower())
-                    self.client.get_hi_data(path)

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -271,7 +271,7 @@ class Client(QObject):
         :return: Normalized version of ``path``.
         """
         # Ensure lowercase
-        path = path.lower().lstrip('/')
+        path = path.lower().strip().lstrip('/')
         parent_path = self.parent_path.lower().lstrip('/')
         file_ext = path.split('.')[-1]
 

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -210,14 +210,18 @@ class Client(QObject):
 
         self.get_hi_data(path, consumer=self.handle_recursive_data)
 
-    def handle_recursive_data(self, path: str, data: dict[str, Any] | bytes | int) -> None:
+    def handle_recursive_data(self, path: str | None, data: dict[str, Any] | bytes | int) -> None:
         """Recursively look through JSON data for resource paths.
+
+        If only providing data (from local or otherwise), you can call this function with
+        a path value of ``None``.
 
         :param path: Path data is from.
         :param data: Data received from path. If not JSON, return early.
         """
         # This set is shared between all recursive calls, so no duplicate searches should occur
-        self.searched_paths.add(path)
+        if path is not None:
+            self.searched_paths.add(path)
 
         if isinstance(data, (bytes, int)):
             # Return early, decrementing counter

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -279,11 +279,14 @@ class Client(QObject):
         return path
 
     def to_os_path(self, path: str, parent: Path = HI_WEB_DUMP_PATH) -> Path:
-        """Translate a given GET path to the equivalent cache location."""
-        return (parent /
-                self.sub_host.replace('-', '_') /
-                self.parent_path.strip('/') /
-                path.replace('/file/', '/').lower())
+        """Translate a given GET path to the equivalent cache location.
+
+        ``path`` is assumed to be normalized.
+
+        :param path: path to translate.
+        :param parent: OS path to use as parent directory.
+        """
+        return parent / self.sub_host.replace('-', '_') / self.parent_path.strip('/') / path
 
     def to_get_path(self, path: str) -> str:
         """Translate a given cache location to the equivalent GET path."""

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -184,7 +184,7 @@ class Client(QObject):
                 if consumer is not None:
                     consumer(path, response_data)
 
-            self._get(path, finished=handle_reply)
+            self._get(path, finished=handle_reply, timeout=120)
 
         else:
             print(f'READING {path}')

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -303,9 +303,8 @@ class Client(QObject):
 
     def to_get_path(self, path: str) -> str:
         """Translate a given cache location to the equivalent GET path."""
-        resource = path.split(self.parent_path, maxsplit=1)[1]
-        pre, post = resource.split('/', maxsplit=1)
-        return f'{pre}/file/{post}'
+        resource = path.split(self.parent_path, maxsplit=1)[-1]
+        return resource
 
     def refresh_auth(self) -> None:
         """Refresh authentication to Halo Waypoint servers.

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -110,10 +110,9 @@ class Client(QObject):
              ) -> None:
         """Get a :py:class:`Response` from HaloWaypoint.
 
-        :param path: path to append to the API root
-        :param update_auth_on_401: run self._refresh_auth if response status code is 401 Unauthorized
-        :param finished: Key word arguments to pass to the requests GET Request.
-        :param update_auth_on_401: run self._refresh_auth if response status code is 401 Unauthorized
+        :param path: path to append to the API root.
+        :param update_auth_on_401: run self._refresh_auth if response status code is 401 Unauthorized.
+        :param finished: Callback to send finished request to.
         """
         def handle_reply(response: Response):
             if response.code and not response.ok:

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -132,6 +132,9 @@ class Client(QObject):
                 if response.code == 401 and update_auth_on_401 and self.wpauth is not None:
                     self.refresh_auth()
                     self._get(path, False, finished, **kwargs)
+                elif finished is not None:
+                    # Send ERR response to the given consumer
+                    finished(response)
 
             elif finished is not None:
                 # Send OK response to the given consumer

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -59,6 +59,7 @@ class Client(QObject):
         self.parent_path: str = '/hi/'
         self.sub_host: str = self.endpoints['endpoints']['gameCmsService']['subdomain']
         self.searched_paths: set[str] = set()
+        self.finishedSearch.connect(self.searched_paths.clear)
 
         self._token: str | None = kwargs.pop('token', os.getenv('HI_SPARTAN_AUTH', None))
         if self._token is None and HI_TOKEN_PATH.is_file():

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -224,10 +224,11 @@ class Client(QObject):
             self.searched_paths.add(path)
 
         if isinstance(data, (bytes, int)):
-            # Return early, decrementing counter
-            self._recursive_calls_in_progress -= 1
-            if not self._recursive_calls_in_progress:
-                self.finishedSearch.emit()
+            if path is not None:
+                # Return early, decrementing counter
+                self._recursive_calls_in_progress -= 1
+                if not self._recursive_calls_in_progress:
+                    self.finishedSearch.emit()
 
             return
 
@@ -253,9 +254,10 @@ class Client(QObject):
                     self.searched_paths.add(new_path)
                     self.recursive_search(new_path)
 
-        self._recursive_calls_in_progress -= 1
-        if not self._recursive_calls_in_progress:
-            self.finishedSearch.emit()
+        if path is not None:
+            self._recursive_calls_in_progress -= 1
+            if not self._recursive_calls_in_progress:
+                self.finishedSearch.emit()
 
     def hidden_key(self) -> str:
         """:return: The first and last 3 characters of the waypoint token, seperated by periods."""

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -122,12 +122,10 @@ class Client(QObject):
         """
         def handle_reply(response: Response):
             if not response.code or response.headers.get('Content-Type') is not None and not response.data:
-                # If response finished but was malformed, wait 500ms and retry.
-                print('RETRYING', response.url)
-                QCoreApplication.processEvents(QEventLoop.ProcessEventsFlag.AllEvents, 500)
-                self._get(path, update_auth_on_401, finished, **kwargs)
+                print(f'COULDNT GET {response.url}')
+                return
 
-            elif not response.ok:
+            if not response.ok:
                 # Handle errors
                 if response.code == 401 and update_auth_on_401 and self.wpauth is not None:
                     self.refresh_auth()
@@ -189,7 +187,7 @@ class Client(QObject):
             self._get(path, finished=handle_reply)
 
         else:
-            print(path)
+            print(f'READING {path}')
             data: dict[str, Any] | bytes = os_path.read_bytes()
             if os_path.suffix.lstrip('.') in SUPPORTED_IMAGE_EXTENSIONS:
                 self.receivedData.emit(path, data)


### PR DESCRIPTION
Closes #70

This PR changes the request approach from 2-threaded synchronous requests to single-threaded asynchronous requests

Before this change, there was a `RecursiveSearch` worker thread that synchronously sent requests and analyzed their responses for paths linked together in JSON data.

I would have preferred to keep a multi-threaded approach as to not block the GUI, but `QNetworkAccessManager` does not work asynchronously cross-thread, and manually changing the `Client`'s manager to one created inside a worker-thread causes a multitude of strange crashes that were impossible to debug. Even just putting the Client on it's own thread instead of using worker-threads causes a deadlock on startup.

While this approach may cause the GUI to be extremely laggy, it is at least 6x faster than before, and also exposes a new method allowing for #71 to be implemented.