### PR TITLE
Ability to Scan Arbitrary JSON Files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- Ability to scan arbitrary JSON files, from [gh-80](https://github.com/Cubicpath/HaloInfiniteGetter/pull/80)
 - Ability to select text in Message Boxes
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Recursively scan a given JSON resource for paths to more resources, ignoring alr
 This results in caching ALL resources that are referenced by any other resource with some tie to the original
 resource path.
 
+If you want to scan your own json file(s) for resource paths, you can use the `Scan Files...` tool in the
+`Tools` context menu.
+
 ### Cache Explorer:
 You can view all cached files using the Cache Explorer, which is on the left-hand side of the main window.
 

--- a/src/hi_getter/gui/__init__.py
+++ b/src/hi_getter/gui/__init__.py
@@ -17,6 +17,7 @@ __all__ = (
     'LicenseViewer',
     'PasteLineEdit',
     'ReadmeViewer',
+    'ScanSelectorDialog',
     'SettingsWindow',
     'Theme',
     'ToolsContextMenu',
@@ -42,4 +43,5 @@ from .windows import ChangelogViewer
 from .windows import ExceptionReporter
 from .windows import LicenseViewer
 from .windows import ReadmeViewer
+from .windows import ScanSelectorDialog
 from .windows import SettingsWindow

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -199,6 +199,7 @@ class GetterApp(Singleton, QApplication):
         from .windows import ChangelogViewer
         from .windows import LicenseViewer
         from .windows import ReadmeViewer
+        from .windows import ScanSelectorDialog
         from .windows import SettingsWindow
 
         SettingsWindow.create(QSize(420, 600))
@@ -211,6 +212,7 @@ class GetterApp(Singleton, QApplication):
         self._windows['changelog_viewer'] = ChangelogViewer()
         self._windows['license_viewer'] = LicenseViewer()
         self._windows['readme_viewer'] = ReadmeViewer()
+        self._windows['scan_selector'] = ScanSelectorDialog()
         self._windows['settings'] = SettingsWindow.instance()  # type: ignore
         self._windows['app'] = AppWindow.instance()            # type: ignore
 

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -497,6 +497,19 @@ class GetterApp(Singleton, QApplication):
         # Set the default icon for all windows.
         self.setWindowIcon(self.icon_store['hi'])
 
+    def warn_for(self, warning_key: str) -> None:
+        """One-time warning for users of application.
+
+        :param warning_key: language key to show dialog for and to write in the ``.warned`` config file.
+        """
+        with (HI_CONFIG_PATH / '.warned').open(mode='a+', encoding='utf8') as warned_file:
+            warned_file.seek(0)
+            acknowledged_warnings: set[str] = {line.strip() for line in warned_file.readlines()}
+
+            if warning_key not in acknowledged_warnings:
+                self.show_dialog(warning_key)
+                warned_file.write(f'{warning_key}\n')
+
     def get_theme_icon(self, icon: str) -> QIcon:
         """Return the icon for the given theme.
 

--- a/src/hi_getter/gui/menus/tools.py
+++ b/src/hi_getter/gui/menus/tools.py
@@ -66,6 +66,12 @@ class ToolsContextMenu(QMenu):
 
         # noinspection PyUnresolvedReferences
         init_objects({
+            (scan_selector := QAction(self)): {
+                'text': tr('gui.menus.tools.scan_selector_dialog'),
+                'icon': self.style().standardIcon(QStyle.StandardPixmap.SP_FileDialogContentsView),
+                'triggered': app().windows['scan_selector'].show
+            },
+
             (shortcut_tool := QAction(self)): {
                 'text': tr('gui.menus.tools.create_shortcut'),
                 'icon': self.style().standardIcon(QStyle.StandardPixmap.SP_DesktopIcon),
@@ -80,5 +86,6 @@ class ToolsContextMenu(QMenu):
         })
 
         add_menu_items(self, [
-            'Tools', shortcut_tool, exception_reporter
+            'Network', scan_selector,
+            'Other', shortcut_tool, exception_reporter
         ])

--- a/src/hi_getter/gui/windows/__init__.py
+++ b/src/hi_getter/gui/windows/__init__.py
@@ -9,6 +9,7 @@ __all__ = (
     'ExceptionReporter',
     'LicenseViewer',
     'ReadmeViewer',
+    'ScanSelectorDialog',
     'SettingsWindow',
 )
 
@@ -17,4 +18,5 @@ from .changelog_viewer import ChangelogViewer
 from .exception_reporter import ExceptionReporter
 from .license_viewer import LicenseViewer
 from .readme_viewer import ReadmeViewer
+from .scan_selector_dialog import ScanSelectorDialog
 from .settings import SettingsWindow

--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -592,14 +592,7 @@ class AppWindow(Singleton, QMainWindow):
 
         Displays a photosensitivity warning for first-time use.
         """
-        with (HI_CONFIG_PATH / '.warned').open(mode='a+', encoding='utf8') as warned_file:
-            warned_file.seek(0)
-            acknowledged_warnings: set[str] = {line.strip() for line in warned_file.readlines()}
-
-            if 'warnings.photosensitivity.scan' not in acknowledged_warnings:
-                app().show_dialog('warnings.photosensitivity.scan')
-                warned_file.write('warnings.photosensitivity.scan\n')
-
+        app().warn_for('warnings.photosensitivity.scan')
         app().client.searched_paths.clear()
         self.use_input(scan=True)
 

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -16,6 +16,7 @@ from PySide6.QtCore import *
 from PySide6.QtGui import *
 from PySide6.QtWidgets import *
 
+from ...constants import *
 from ...utils import init_layouts
 from ...utils import init_objects
 from ..aliases import app
@@ -113,7 +114,7 @@ class ScanSelectorDialog(QWidget):
     def select_files(self) -> None:
         """Select JSON files to scan through a file dialog."""
         names: list[str] = QFileDialog.getOpenFileNames(self, caption=tr('gui.scan_selector_dialog.select_files'),
-                                                        dir=str(Path.home() / 'Downloads'),
+                                                        dir=str(HI_WEB_DUMP_PATH),
                                                         filter=_SCAN_FILTER)[0]
         # If no filenames are selected, do nothing.
         if not names:

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -8,6 +8,7 @@ __all__ = (
     'ScanSelectorDialog',
 )
 
+from pathlib import Path
 
 from PySide6.QtCore import *
 from PySide6.QtGui import *
@@ -16,6 +17,13 @@ from PySide6.QtWidgets import *
 from ...utils import init_layouts
 from ...utils import init_objects
 from ..aliases import app
+from ..aliases import tr
+
+
+_SCAN_FILTER: str = ';;'.join((
+    'JSON Files (*.json)',
+    'All files (*.*)'
+))
 
 
 class ScanSelectorDialog(QWidget):
@@ -39,6 +47,10 @@ class ScanSelectorDialog(QWidget):
                 'windowIcon': self.style().standardIcon(QStyle.StandardPixmap.SP_FileDialogContentsView),
             },
 
+            (filepaths_selector := QPushButton(self)): {
+                'clicked': self.select_files
+            },
+
             self.scan_button: {
                 # 'clicked': start_sign_in,
             },
@@ -51,19 +63,24 @@ class ScanSelectorDialog(QWidget):
         app().init_translations({
             self.setWindowTitle: 'gui.scan_selector_dialog.title',
             self.filepaths_input.setPlaceholderText: 'gui.scan_selector_dialog.filepaths_placeholder',
+            filepaths_selector.setText: 'gui.scan_selector_dialog.select_files',
 
             self.scan_button.setText: 'gui.scan_selector_dialog.scan',
             cancel_button.setText: 'gui.scan_selector_dialog.cancel'
         })
 
         init_layouts({
+            (input_layout := QHBoxLayout()): {
+                'items': (self.filepaths_input, filepaths_selector)
+            },
+
             (bottom := QHBoxLayout()): {
                 'items': (self.scan_button, cancel_button)
             },
 
             # Main layout
             QVBoxLayout(self): {
-                'items': (self.filepaths_input, bottom)
+                'items': (input_layout, bottom)
             }
         })
 
@@ -72,7 +89,19 @@ class ScanSelectorDialog(QWidget):
 
         self.scan_button.setDisabled(True)
 
+    def select_files(self) -> None:
+        """Select JSON files to scan through a file dialog."""
+        names: list[str] = QFileDialog.getOpenFileNames(self, caption=tr('gui.scan_selector_dialog.select_files'),
+                                                        dir=str(Path.home() / 'Downloads'),
+                                                        filter=_SCAN_FILTER)[0]
+        # If no filenames are selected, do nothing.
+        if not names:
+            return
+
+        # Override input text with a string representation of selected files
+        self.filepaths_input.setText(', '.join(f'"{Path(file)}"' for file in names))
+
     def showEvent(self, event: QShowEvent) -> None:
-        """Reset fields when dialog is shown to user."""
+        """Reset widgets when dialog is shown to user."""
         super().showEvent(event)
         self._reset_widgets()

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -100,6 +100,7 @@ class ScanSelectorDialog(QWidget):
         if not (user_input := self.filepaths_input.text()):
             return
 
+        app().warn_for('warnings.photosensitivity.scan')
         paths: tuple[Path] = tuple(Path(name.strip(' \'\",')) for name in user_input.split(', '))
 
         for i, path in enumerate(paths):

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -22,7 +22,6 @@ from ...utils import init_objects
 from ..aliases import app
 from ..aliases import tr
 
-
 _SCAN_FILTER: str = ';;'.join((
     'JSON Files (*.json)',
     'All files (*.*)'
@@ -48,6 +47,10 @@ class ScanSelectorDialog(QWidget):
                 'windowFlags': Qt.WindowType.Dialog,
                 'windowModality': Qt.WindowModality.ApplicationModal,
                 'windowIcon': self.style().standardIcon(QStyle.StandardPixmap.SP_FileDialogContentsView),
+            },
+
+            self.filepaths_input: {
+                'maxLength': (2 ** 31) - 1,  # Max int for shiboken
             },
 
             (filepaths_selector := QPushButton(self)): {

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -117,6 +117,7 @@ class ScanSelectorDialog(QWidget):
         app().client.finishedSearch.disconnect(app().client._on_finished_search)
         try:
             for i, path in enumerate(paths):
+                path = path.expanduser().resolve(strict=True)
                 data: dict[str, Any] = json.loads(path.read_bytes())
 
                 if i == len(paths) - 1:

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -1,0 +1,78 @@
+###################################################################################################
+#                              MIT Licence (C) 2023 Cubicpath@Github                              #
+###################################################################################################
+"""ScanSelectorDialog implementation."""
+from __future__ import annotations
+
+__all__ = (
+    'ScanSelectorDialog',
+)
+
+
+from PySide6.QtCore import *
+from PySide6.QtGui import *
+from PySide6.QtWidgets import *
+
+from ...utils import init_layouts
+from ...utils import init_objects
+from ..aliases import app
+
+
+class ScanSelectorDialog(QWidget):
+    """A :py:class:`ScanSelectorDialog` which allows you to select JSON files to scan."""
+
+    def __init__(self) -> None:
+        """Create a new :py:class:`SignInDialog`."""
+        super().__init__(None)
+
+        self._init_ui()
+
+    def _init_ui(self) -> None:
+        self.filepaths_input = QLineEdit(self)
+        self.scan_button = QPushButton(self)
+
+        init_objects({
+            self: {
+                'size': {'fixed': (500, 100)},
+                'windowFlags': Qt.WindowType.Dialog,
+                'windowModality': Qt.WindowModality.ApplicationModal,
+                'windowIcon': self.style().standardIcon(QStyle.StandardPixmap.SP_FileDialogContentsView),
+            },
+
+            self.scan_button: {
+                # 'clicked': start_sign_in,
+            },
+
+            (cancel_button := QPushButton(self)): {
+                'clicked': self.close,
+            }
+        })
+
+        app().init_translations({
+            self.setWindowTitle: 'gui.scan_selector_dialog.title',
+            self.filepaths_input.setPlaceholderText: 'gui.scan_selector_dialog.filepaths_placeholder',
+
+            self.scan_button.setText: 'gui.scan_selector_dialog.scan',
+            cancel_button.setText: 'gui.scan_selector_dialog.cancel'
+        })
+
+        init_layouts({
+            (bottom := QHBoxLayout()): {
+                'items': (self.scan_button, cancel_button)
+            },
+
+            # Main layout
+            QVBoxLayout(self): {
+                'items': (self.filepaths_input, bottom)
+            }
+        })
+
+    def _reset_widgets(self) -> None:
+        self.filepaths_input.clear()
+
+        self.scan_button.setDisabled(True)
+
+    def showEvent(self, event: QShowEvent) -> None:
+        """Reset fields when dialog is shown to user."""
+        super().showEvent(event)
+        self._reset_widgets()

--- a/src/hi_getter/gui/windows/scan_selector_dialog.py
+++ b/src/hi_getter/gui/windows/scan_selector_dialog.py
@@ -40,6 +40,7 @@ class ScanSelectorDialog(QWidget):
     def _init_ui(self) -> None:
         self.filepaths_input = QLineEdit(self)
         self.scan_button = QPushButton(self)
+        self.do_recursive = QCheckBox(self)
 
         init_objects({
             self: {
@@ -57,6 +58,10 @@ class ScanSelectorDialog(QWidget):
                 'clicked': self.select_files
             },
 
+            self.do_recursive: {
+                'checked': True
+            },
+
             self.scan_button: {
                 'clicked': self.scan_files,
             },
@@ -70,6 +75,7 @@ class ScanSelectorDialog(QWidget):
             self.setWindowTitle: 'gui.scan_selector_dialog.title',
             self.filepaths_input.setPlaceholderText: 'gui.scan_selector_dialog.filepaths_placeholder',
             filepaths_selector.setText: 'gui.scan_selector_dialog.select_files',
+            self.do_recursive.setText: 'gui.scan_selector_dialog.do_recursive',
 
             self.scan_button.setText: 'gui.scan_selector_dialog.scan',
             cancel_button.setText: 'gui.scan_selector_dialog.cancel'
@@ -86,7 +92,7 @@ class ScanSelectorDialog(QWidget):
 
             # Main layout
             QVBoxLayout(self): {
-                'items': (input_layout, bottom)
+                'items': (input_layout, self.do_recursive, bottom)
             }
         })
 
@@ -112,7 +118,7 @@ class ScanSelectorDialog(QWidget):
             if i == len(paths) - 1:
                 app().client.finishedSearch.connect(app().client._on_finished_search)
 
-            app().client.start_handle_json(data, True)
+            app().client.start_handle_json(data, self.do_recursive.isChecked())
 
         self.close()
 

--- a/src/hi_getter/resources/lang/en.default.json
+++ b/src/hi_getter/resources/lang/en.default.json
@@ -79,6 +79,10 @@
     "gui.outputs.text.label_empty": "Text Output:",
     "gui.readme_viewer.close": "Close",
     "gui.readme_viewer.title": "README Viewer",
+    "gui.scan_selector_dialog.cancel": "Cancel",
+    "gui.scan_selector_dialog.filepaths_placeholder": "PLACEHOLDER",
+    "gui.scan_selector_dialog.scan": "Start Scan",
+    "gui.scan_selector_dialog.title": "Scan Selector",
 
     "gui.menu_bar.title": "Menu Bar",
     "gui.menus.cached_file.copy_contents": "Copy File Contents",
@@ -114,6 +118,7 @@
     "gui.menus.tools.create_shortcut.only_start_menu": "Start Menu",
     "gui.menus.tools.create_shortcut.both": "Both",
     "gui.menus.tools.exception_reporter": "Open Exception Reporter",
+    "gui.menus.tools.scan_selector_dialog": "Scan Files...",
     "gui.status.default": "No current exceptions...",
     "gui.status_bar.title": "Status Bar",
 

--- a/src/hi_getter/resources/lang/en.default.json
+++ b/src/hi_getter/resources/lang/en.default.json
@@ -80,8 +80,9 @@
     "gui.readme_viewer.close": "Close",
     "gui.readme_viewer.title": "README Viewer",
     "gui.scan_selector_dialog.cancel": "Cancel",
-    "gui.scan_selector_dialog.filepaths_placeholder": "PLACEHOLDER",
+    "gui.scan_selector_dialog.filepaths_placeholder": "File paths seperated by commas (ex: \"D:\\my file.json\", \"~\\other_file.json\")",
     "gui.scan_selector_dialog.scan": "Start Scan",
+    "gui.scan_selector_dialog.select_files": "Select Files...",
     "gui.scan_selector_dialog.title": "Scan Selector",
 
     "gui.menu_bar.title": "Menu Bar",

--- a/src/hi_getter/resources/lang/en.default.json
+++ b/src/hi_getter/resources/lang/en.default.json
@@ -80,6 +80,7 @@
     "gui.readme_viewer.close": "Close",
     "gui.readme_viewer.title": "README Viewer",
     "gui.scan_selector_dialog.cancel": "Cancel",
+    "gui.scan_selector_dialog.do_recursive": "Recursive",
     "gui.scan_selector_dialog.filepaths_placeholder": "File paths seperated by commas (ex: \"D:\\my file.json\", \"~\\other_file.json\")",
     "gui.scan_selector_dialog.scan": "Start Scan",
     "gui.scan_selector_dialog.select_files": "Select Files...",


### PR DESCRIPTION
Closes #71

This PR adds the ability to scan any JSON file through a file dialog prompt, which can be accessed through the `Scan Files...` tool under the `Tools` context menu.

Multiple selected paths are separated by commas, quotes are optional. Ex: `"D:\my file.json", ~\other_file.json`

This process is treated as a single scan by the `Client`, so any paths already scanned through ties to one file, will not be scanned again in another.