### PR TITLE
Track ETag Changes

### DIFF
--- a/src/hi_getter/constants.py
+++ b/src/hi_getter/constants.py
@@ -8,6 +8,7 @@ __all__ = (
     'BYTE_UNITS',
     'HI_CACHE_PATH',
     'HI_CONFIG_PATH',
+    'HI_DATE_FORMAT',
     'HI_PACKAGE_NAME',
     'HI_PATH_PATTERN',
     'HI_RESOURCE_PATH',
@@ -49,6 +50,9 @@ SUPPORTED_IMAGE_MIME_TYPES: Final[frozenset[str]] = frozenset({
 """Set containing all image mime types supported by application."""
 
 # Strings
+
+HI_DATE_FORMAT: Final[str] = '%Y-%m-%dT%H:%M:%S.%fZ'
+"""Format to use for datetime objects."""
 
 HI_PACKAGE_NAME: Final[str] = __package__.split('.', maxsplit=1)[0]
 """The base package name for this application, for use in sub-packages."""

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -215,6 +215,10 @@ class GetterApp(Singleton, QApplication):
             DeferredCallable(self.update_stylesheet),
             TomlEvents.Set, event_predicate=lambda e: e.key == 'gui/themes/selected')
 
+        EventBus['settings'].subscribe(
+            lambda *_: setattr(self.client, 'check_etags', self.settings['network/client/check_etags']),
+            TomlEvents.Set, event_predicate=lambda e: e.key == 'network/client/check_etags')
+
         if not self.settings['ignore_updates']:
             self.version_checker.newerVersion.connect(self._upgrade_version_dialog)
 

--- a/src/hi_getter/gui/app.py
+++ b/src/hi_getter/gui/app.py
@@ -134,6 +134,7 @@ class GetterApp(Singleton, QApplication):
         # Must load client last, but before windows
         self.load_env(verbose=True)
         self.client = Client(self)
+        self.client.check_etags = self.settings['network/client/check_etags']  # type: ignore
         self._connect_events()
 
         # Setup window instances

--- a/src/hi_getter/gui/menus/cache_index.py
+++ b/src/hi_getter/gui/menus/cache_index.py
@@ -52,7 +52,7 @@ class CacheIndexContextMenu(QMenu):
             dir_path = file_path.parent
 
         try:
-            os_path = app().client.to_get_path(file_path.as_posix())
+            os_path = app().client.to_get_path(file_path)
         except (IndexError, ValueError):
             os_path = ''
 

--- a/src/hi_getter/gui/windows/application.py
+++ b/src/hi_getter/gui/windows/application.py
@@ -26,6 +26,7 @@ from ...exception_hook import ExceptionEvent
 from ...models import DeferredCallable
 from ...models import DistributedCallable
 from ...models import Singleton
+from ...network.client import save_etags
 from ...tomlfile import TomlEvents
 from ...utils import init_layouts
 from ...utils import init_objects
@@ -497,7 +498,7 @@ class AppWindow(Singleton, QMainWindow):
             if scan:
                 app().client.recursive_search(search_path)
             else:
-                app().client.get_hi_data(search_path)
+                app().client.get_hi_data(search_path, consumer=DeferredCallable(save_etags, app().client.etags))
 
     def update_image(self, _: str, data: bytes) -> None:
         """Update the image output with the given data."""

--- a/src/hi_getter/gui/windows/settings.py
+++ b/src/hi_getter/gui/windows/settings.py
@@ -112,12 +112,12 @@ class SettingsWindow(Singleton, QWidget):
         (
             self.key_set_button, self.token_clear_button,
             self.theme_dropdown, self.aspect_ratio_dropdown, self.transformation_dropdown,
-            self.line_wrap_dropdown, self.icon_mode_dropdown,
+            self.line_wrap_dropdown, self.icon_mode_dropdown, self.check_etags_checkbox,
             self.key_field
         ) = (
             QPushButton(self), QPushButton(self),
             TranslatableComboBox(self), TranslatableComboBox(self), TranslatableComboBox(self),
-            TranslatableComboBox(self), TranslatableComboBox(self),
+            TranslatableComboBox(self), TranslatableComboBox(self), QCheckBox(self),
             PasteLineEdit(self)
         )
 
@@ -168,6 +168,14 @@ class SettingsWindow(Singleton, QWidget):
             self.token_clear_button: {
                 'disabled': not app().client.token,
                 'clicked': clear_token
+            },
+            self.check_etags_checkbox: {
+                'checked': app().settings['network/client/check_etags'],
+                'stateChanged': DeferredCallable(
+                    app().settings.__setitem__,
+                    'network/client/check_etags',
+                    self.check_etags_checkbox.isChecked
+                ),
             },
 
             # Line editors
@@ -258,7 +266,8 @@ class SettingsWindow(Singleton, QWidget):
             open_editor_button.setText: 'gui.settings.open_editor',
             key_show_button.setText: 'gui.settings.auth.edit',
             self.key_set_button.setText: 'gui.settings.auth.set',
-            self.token_clear_button.setText: 'gui.settings.auth.clear_token'
+            self.token_clear_button.setText: 'gui.settings.auth.clear_token',
+            self.check_etags_checkbox.setText: 'gui.settings.check_etags'
         })
 
         init_layouts({
@@ -291,7 +300,7 @@ class SettingsWindow(Singleton, QWidget):
                 'items': [theme_label, self.theme_dropdown]
             },
             (middle := QVBoxLayout()): {
-                'items': [theme_layout, output_layout, cache_layout]
+                'items': [theme_layout, output_layout, cache_layout, self.check_etags_checkbox]
             },
 
             # Add top widgets

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -282,6 +282,7 @@ class Client(QObject):
         :param path: Path to get data from.
         :param consumer: Consumer to send received data to.
         :param emit_signals: Whether to emit received* signals.
+        :param check_etag: Whether to call ``_check_etag`` if path is already cached.
         :raises ValueError: If the response is not JSON or a supported image type.
         """
         path = self.normalize_search_path(path)

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -424,9 +424,15 @@ class Client(QObject):
         return parent / self.sub_host.replace('-', '_') / self.parent_path.strip('/') / path
 
     def to_get_path(self, path: Path) -> str:
-        """Translate a given cache location to the equivalent GET path."""
+        """Translate a given cache location to the equivalent GET path.
+
+        Return an empty string if path doesn't include an endpoint following the parent_path.
+        """
         no_etag: Path = path.with_stem(path.stem.split('_etag+', maxsplit=1)[0])
         resource = no_etag.as_posix().split(self.parent_path, maxsplit=1)[-1]
+        if Path(resource).is_absolute():
+            return ''
+
         return resource
 
     def refresh_auth(self) -> None:

--- a/src/hi_getter/network/client.py
+++ b/src/hi_getter/network/client.py
@@ -419,9 +419,10 @@ class Client(QObject):
         """
         return parent / self.sub_host.replace('-', '_') / self.parent_path.strip('/') / path
 
-    def to_get_path(self, path: str) -> str:
+    def to_get_path(self, path: Path) -> str:
         """Translate a given cache location to the equivalent GET path."""
-        resource = path.split(self.parent_path, maxsplit=1)[-1]
+        no_etag: Path = path.with_stem(path.stem.split('_etag+', maxsplit=1)[0])
+        resource = no_etag.as_posix().split(self.parent_path, maxsplit=1)[-1]
         return resource
 
     def refresh_auth(self) -> None:

--- a/src/hi_getter/network/version_check.py
+++ b/src/hi_getter/network/version_check.py
@@ -68,7 +68,7 @@ class VersionChecker(QObject):
             # Sort versions on date released
             versions: list[str] = sorted(
                 releases := reply.json['releases'],
-                key=lambda v: datetime.strptime(releases[v][0]['upload_time_iso_8601'], '%Y-%m-%dT%H:%M:%S.%fZ')
+                key=lambda v: datetime.strptime(releases[v][0]['upload_time_iso_8601'], HI_DATE_FORMAT)
             )
 
             # Get local version of given package. Use __version__ attribute for own package.

--- a/src/hi_getter/resources/default_settings.toml
+++ b/src/hi_getter/resources/default_settings.toml
@@ -1,6 +1,9 @@
 ignore_updates = false
 language = "en-US"
 
+[network.client]
+check_etags = true  # Whether to check for new versions of cached files
+
 [gui.window]
 x_size = 900 # Minimum value of 100
 y_size = 500 # Minimum value of 100

--- a/src/hi_getter/resources/lang/en.default.json
+++ b/src/hi_getter/resources/lang/en.default.json
@@ -131,6 +131,7 @@
     "gui.settings.cache.icon_mode.default": "Default",
     "gui.settings.cache.icon_mode.no_icons": "No Icons",
     "gui.settings.cache.icon_mode.preview": "Preview Images",
+    "gui.settings.check_etags": "Update Cached Resources",
     "gui.settings.export": "Export Settings",
     "gui.settings.import": "Import Settings",
     "gui.settings.media.aspect_ratio": "Aspect Ratio:",


### PR DESCRIPTION
Closes #83

This PR enables the Client to send `HEAD` requests to check for ETags, which are a version signifier for a given endpoint's data. This gives HaloInfiniteGetter the ability to track changes to already-cached resources. Old files are cached to the `old_files` directory (next to `cached_requests`) with a `_etag+{etag value}` suffix appended to the file's name.

`etags.json` is a new file meant to keep track of version precedence. When an ETag is cached, a timestamp is kept along with its given uri path. Example: 
```json
{
  "timestamps" : {
    "vgfLDxMZD+BSHguzw+PFiw++oGU7pTuQb99c+Q==": "2023-02-26T21:13:16.000000Z",
    "Fnw60M2vqt83tUhMAwYsNVVJFLBSGSgTBW4X6g==": "2023-02-26T21:13:16.000000Z",
    "uuIs+RDI4KR4TqTi7TG6pu58TtyMYj7zw895RQ==": "2023-02-28T21:14:37.000000Z"
  },
  "paths": {
    "gamecms-hacs.svc.halowaypoint.com/hi/progression/file/currency/offerings/small.json": {
      "etags": [
        "vgfLDxMZD+BSHguzw+PFiw++oGU7pTuQb99c+Q=="
      ]
    },
    "gamecms-hacs.svc.halowaypoint.com/hi/progression/file/currency/offerings/large.json": {
      "etags": [
        "Fnw60M2vqt83tUhMAwYsNVVJFLBSGSgTBW4X6g==",
        "uuIs+RDI4KR4TqTi7TG6pu58TtyMYj7zw895RQ=="
      ]
    }
  },
}
```

Process:
1. You get an endpoint's data, caching the ETag in `etags.json`
2. A new version is uploaded to the Waypoint servers, changing it's ETag value
3. When you get that same resource again, the Client sends a `HEAD` request to check if the ETag has in fact changed
4. If the ETag is different, the old version is moved and the full resource is redownloaded.